### PR TITLE
Update telepat.js

### DIFF
--- a/dist/telepat.js
+++ b/dist/telepat.js
@@ -442,7 +442,7 @@ function error(string) {
 
 function updateContexts() {
   API.get('context/all', {}, function(err, res) {
-      Telepat.contexts = res.body;
+      Telepat.contexts = res.body.content;
       Event.emit('contexts-update');
     })
 }


### PR DESCRIPTION
get actual array of objects from jQuery result instead of using it as an array of contexts.