### PR TITLE
Update script.js

### DIFF
--- a/example/script.js
+++ b/example/script.js
@@ -71,7 +71,7 @@ function appendToList(key, value) {
 }
 
 function subscribe() {
-  eventChannel = Telepat.subscribe(Object.keys(Telepat.contexts)[0], channel, function () {
+  eventChannel = Telepat.subscribe(Telepat.contexts[0].id, channel, function () {
     $('#message').empty();
     $.each(eventChannel.objects, function (key, value) {
       appendToList(key, value);


### PR DESCRIPTION
Previously, Telepat.contexts was a jQuery xhr result object. When that is fixed, this should just get the first context and get it's `id` value (according to the documentation on Channels).